### PR TITLE
Use ansible_facts to reference facts

### DIFF
--- a/tasks/timezone.yml
+++ b/tasks/timezone.yml
@@ -2,8 +2,8 @@
 - name: include platform vars
   include_vars: "{{ item }}"
   with_first_found:
-    - "../vars/{{ ansible_distribution }}.yml"
-    - "../vars/{{ ansible_os_family }}.yml"
+    - "../vars/{{ ansible_facts.distribution }}.yml"
+    - "../vars/{{ ansible_facts.os_family }}.yml"
   tags: ['timezone']
 
 - name: Install tzdata for Debian based distros
@@ -12,7 +12,7 @@
     update_cache: true
     cache_valid_time: 86400
     state: present
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts.os_family == 'Debian'
   tags: ['timezone']
   become: true
 
@@ -20,7 +20,7 @@
   yum:
     name: "{{ timezone_package }}"
     state: present
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts.os_family == 'RedHat'
   tags: ['timezone']
   become: true
 
@@ -28,13 +28,13 @@
   pacman:
     name: "{{ timezone_package }}"
     state: present
-  when: ansible_os_family == 'Archlinux' or ansible_os_family == 'Arch Linux'
+  when: ansible_facts.os_family == 'Archlinux' or ansible_facts.os_family == 'Arch Linux'
   tags: ['timezone']
   become: true
 
 - name: Set timezone config
   template:
-    src: "timezone-{{ ansible_os_family }}.j2"
+    src: "timezone-{{ ansible_facts.os_family }}.j2"
     dest: "{{ timezone_file }}"
   tags: ['timezone']
   become: true


### PR DESCRIPTION
By default, Ansible injects a variable for every fact, prefixed with
ansible_. This can result in a large number of variables for each host,
which at scale can incur a performance penalty. Ansible provides a
configuration option [0] that can be set to False to prevent this
injection of facts. In this case, facts should be referenced via
ansible_facts.<fact>.

This change updates all references to Ansible facts from using
individual fact variables to using the items in the
ansible_facts dictionary. This allows users to disable fact variable
injection in their Ansible configuration, which may provide some
performance improvement.

[0] https://docs.ansible.com/ansible/latest/reference_appendices/config.html#inject-facts-as-vars