### PR TITLE
Fix depreciation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,2 @@
 ---
-- include: timezone.yml
+- import_playbook: timezone.yml


### PR DESCRIPTION
Resolves:
````bash
[DEPRECATION WARNING]: "include" is deprecated, use include_tasks/import_tasks instead. This feature will be removed in version 2.16. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
````