### PR TITLE
import_playbook cannot be used here

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,2 @@
 ---
-- import_playbook: timezone.yml
+- import_tasks: timezone.yml


### PR DESCRIPTION
Fixes the following error:

ERROR! this task 'import_playbook' has extra params, which is only allowed in the following modules: ansible.builtin.raw, win_command, meta, ansible.builtin.group_by, ansible.legacy.win_shell, win_shell, ansible.builtin.set_fact, set_fact, ansible.legacy.import_role, group_by, include_vars, include, ansible.legacy.include_role, include_role, ansible.builtin.shell, ansible.legacy.include_tasks, ansible.legacy.win_command, import_tasks, add_host, script, ansible.legacy.set_fact, ansible.builtin.include_role, ansible.builtin.command, ansible.legacy.group_by, ansible.builtin.win_command, ansible.builtin.import_tasks, ansible.builtin.include_vars, ansible.builtin.include, ansible.legacy.import_tasks, ansible.legacy.include_vars, import_role, ansible.legacy.command, include_tasks, ansible.legacy.script, ansible.builtin.add_host, ansible.windows.win_shell, ansible.windows.win_command, ansible.legacy.raw, ansible.legacy.add_host, ansible.legacy.shell, ansible.builtin.include_tasks, shell, ansible.builtin.win_shell, ansible.legacy.include, ansible.builtin.script, command, raw, ansible.builtin.import_role, ansible.legacy.meta, ansible.builtin.meta